### PR TITLE
MultiLepCalc add genJetNoClean variables

### DIFF
--- a/LJMet/plugins/MultiLepCalc.cc
+++ b/LJMet/plugins/MultiLepCalc.cc
@@ -1225,6 +1225,11 @@ void MultiLepCalc::AnalyzeGenInfo(edm::Event const & event, BaseEventSelector * 
     std::vector <double> genJetPhi;
     std::vector <double> genJetEnergy;
 
+    std::vector <double> genJetPtNoClean;
+    std::vector <double> genJetEtaNoClean;
+    std::vector <double> genJetPhiNoClean;
+    std::vector <double> genJetEnergyNoClean;
+
     //Tau Decay Lepton
     double genTDLPt = -9999.;
     double genTDLEta = -9999.;
@@ -1468,8 +1473,10 @@ void MultiLepCalc::AnalyzeGenInfo(edm::Event const & event, BaseEventSelector * 
         TLorentzVector tmpLep;
         TLorentzVector tmpCand;
         std::vector<TLorentzVector> tmpVec;
+        std::vector<TLorentzVector> tmpVecNoClean;  
         for(const reco::GenJet &j : *genJets){
             tmpJet.SetPtEtaPhiE(j.pt(),j.eta(),j.phi(),j.energy());
+            tmpVecNoClean.push_back(tmpJet);
             if (cleanGenJets) {
 	            for(size_t k = 0; k < vGenLep.size(); k++){
                     tmpLep = vGenLep[k];
@@ -1490,6 +1497,13 @@ void MultiLepCalc::AnalyzeGenInfo(edm::Event const & event, BaseEventSelector * 
                 }
             }
             tmpVec.push_back(tmpJet);
+        }
+        std::sort(tmpVecNoClean.begin(), tmpVecNoClean.end(), SortLVByPt);
+        for (unsigned int i = 0; i < tmpVecNoClean.size(); i++) {
+            genJetPtNoClean     . push_back(tmpVecNoClean.at(i).Pt());
+            genJetEtaNoClean    . push_back(tmpVecNoClean.at(i).Eta());
+            genJetPhiNoClean    . push_back(tmpVecNoClean.at(i).Phi());
+            genJetEnergyNoClean . push_back(tmpVecNoClean.at(i).Energy());
         }
         std::sort(tmpVec.begin(), tmpVec.end(), SortLVByPt);
         for (unsigned int i = 0; i < tmpVec.size(); i++) {
@@ -1519,6 +1533,12 @@ void MultiLepCalc::AnalyzeGenInfo(edm::Event const & event, BaseEventSelector * 
     SetValue("genJetEta"   , genJetEta);
     SetValue("genJetPhi"   , genJetPhi);
     SetValue("genJetEnergy", genJetEnergy);
+
+    SetValue("genJetPtNoClean"    , genJetPtNoClean);
+    SetValue("genJetEtaNoClean"   , genJetEtaNoClean);
+    SetValue("genJetPhiNoClean"   , genJetPhiNoClean);
+    SetValue("genJetEnergyNoClean", genJetEnergyNoClean);
+
 
     SetValue("genBSLPt"    , genBSLPt);
     SetValue("genBSLEta"   , genBSLEta);


### PR DESCRIPTION
Adding GenJet vars before cleaning, not affecting existing tree branches