### PR TITLE
10 2 x full run2data

### DIFF
--- a/LJMet/plugins/TTbarMassCalc.cc
+++ b/LJMet/plugins/TTbarMassCalc.cc
@@ -111,10 +111,18 @@ int TTbarMassCalc::AnalyzeEvent(edm::Event const & event, BaseEventSelector * se
 
 	    const reco::Candidate *W = p.daughter(1);
 	    if(abs(d2Id)==5) W = p.daughter(0);
-
-	    while(W->numberOfDaughters() == 1) W = W->daughter(0);	    
-	    if(W->daughter(1)->pdgId() == 22) W = W->daughter(0);	    
-	    while(W->numberOfDaughters() == 1) W = W->daughter(0);	    
+    
+		bool isHardProcess = false;
+		while(!isHardProcess){
+			isHardProcess = true;
+			for(size_t iWdau = 0; iWdau < W->numberOfDaughters(); iWdau++){
+				int WdauId = W->daughter(iWdau)->pdgId();
+				if(abs(WdauId) == 24){
+					W = W->daughter(iWdau);
+					isHardProcess = false;
+					}
+				}
+			}
 
 	    size_t nWDs = W->numberOfDaughters();
 	    if(nWDs > 2) cout << "W daughters: " << nWDs << endl;

--- a/LJMet/runFWLJMet_diLep2017.py
+++ b/LJMet/runFWLJMet_diLep2017.py
@@ -640,6 +640,7 @@ BestCalc_cfg = cms.PSet(
     )
 HOTTaggerCalc_cfg = cms.PSet(
 
+    genParticles     = cms.InputTag("prunedGenParticles"),
     ak4PtCut         = cms.double(20),
     qgTaggerKey      = cms.string('QGTagger'),
     deepCSVBJetTags  = cms.string('pfDeepCSVJetTags'),

--- a/LJMet/runFWLJMet_diLep2017_multipleTree.py
+++ b/LJMet/runFWLJMet_diLep2017_multipleTree.py
@@ -640,6 +640,7 @@ BestCalc_cfg = cms.PSet(
     )
 HOTTaggerCalc_cfg = cms.PSet(
 
+    genParticles     = cms.InputTag("prunedGenParticles"),
     ak4PtCut         = cms.double(20),
     qgTaggerKey      = cms.string('QGTagger'),
     deepCSVBJetTags  = cms.string('pfDeepCSVJetTags'),

--- a/LJMet/runFWLJMet_diLep2018.py
+++ b/LJMet/runFWLJMet_diLep2018.py
@@ -641,6 +641,7 @@ BestCalc_cfg = cms.PSet(
     )
 HOTTaggerCalc_cfg = cms.PSet(
 
+    genParticles     = cms.InputTag("prunedGenParticles"),
     ak4PtCut         = cms.double(20),
     qgTaggerKey      = cms.string('QGTagger'),
     deepCSVBJetTags  = cms.string('pfDeepCSVJetTags'),

--- a/LJMet/runFWLJMet_diLep2018_multipleTree.py
+++ b/LJMet/runFWLJMet_diLep2018_multipleTree.py
@@ -641,6 +641,7 @@ BestCalc_cfg = cms.PSet(
     )
 HOTTaggerCalc_cfg = cms.PSet(
 
+    genParticles     = cms.InputTag("prunedGenParticles"),
     ak4PtCut         = cms.double(20),
     qgTaggerKey      = cms.string('QGTagger'),
     deepCSVBJetTags  = cms.string('pfDeepCSVJetTags'),

--- a/LJMet/runFWLJMet_diLepFakeRate2017.py
+++ b/LJMet/runFWLJMet_diLepFakeRate2017.py
@@ -636,6 +636,7 @@ BestCalc_cfg = cms.PSet(
     )
 HOTTaggerCalc_cfg = cms.PSet(
 
+    genParticles     = cms.InputTag("prunedGenParticles"),
     ak4PtCut         = cms.double(20),
     qgTaggerKey      = cms.string('QGTagger'),
     deepCSVBJetTags  = cms.string('pfDeepCSVJetTags'),

--- a/LJMet/runFWLJMet_diLepFakeRate2018.py
+++ b/LJMet/runFWLJMet_diLepFakeRate2018.py
@@ -637,6 +637,7 @@ BestCalc_cfg = cms.PSet(
     )
 HOTTaggerCalc_cfg = cms.PSet(
 
+    genParticles     = cms.InputTag("prunedGenParticles"),
     ak4PtCut         = cms.double(20),
     qgTaggerKey      = cms.string('QGTagger'),
     deepCSVBJetTags  = cms.string('pfDeepCSVJetTags'),

--- a/LJMet/runFWLJMet_multiLep2017.py
+++ b/LJMet/runFWLJMet_multiLep2017.py
@@ -667,6 +667,7 @@ BestCalc_cfg = cms.PSet(
     )
 HOTTaggerCalc_cfg = cms.PSet(
 
+    genParticles     = cms.InputTag("prunedGenParticles"),
     ak4PtCut         = cms.double(20),
     qgTaggerKey      = cms.string('QGTagger'),
     deepCSVBJetTags  = cms.string('pfDeepCSVJetTags'),

--- a/LJMet/runFWLJMet_multiLep2017_multipleTree.py
+++ b/LJMet/runFWLJMet_multiLep2017_multipleTree.py
@@ -667,6 +667,7 @@ BestCalc_cfg = cms.PSet(
     )
 HOTTaggerCalc_cfg = cms.PSet(
 
+    genParticles     = cms.InputTag("prunedGenParticles"),
     ak4PtCut         = cms.double(20),
     qgTaggerKey      = cms.string('QGTagger'),
     deepCSVBJetTags  = cms.string('pfDeepCSVJetTags'),

--- a/LJMet/runFWLJMet_multiLep2018.py
+++ b/LJMet/runFWLJMet_multiLep2018.py
@@ -673,6 +673,7 @@ BestCalc_cfg = cms.PSet(
 
 HOTTaggerCalc_cfg = cms.PSet(
 
+    genParticles     = cms.InputTag("prunedGenParticles"),
     ak4PtCut         = cms.double(20),
     qgTaggerKey      = cms.string('QGTagger'),
     deepCSVBJetTags  = cms.string('pfDeepCSVJetTags'),

--- a/LJMet/runFWLJMet_multiLep2018_multipleTree.py
+++ b/LJMet/runFWLJMet_multiLep2018_multipleTree.py
@@ -673,6 +673,7 @@ BestCalc_cfg = cms.PSet(
 
 HOTTaggerCalc_cfg = cms.PSet(
 
+    genParticles     = cms.InputTag("prunedGenParticles"),
     ak4PtCut         = cms.double(20),
     qgTaggerKey      = cms.string('QGTagger'),
     deepCSVBJetTags  = cms.string('pfDeepCSVJetTags'),

--- a/LJMet/runFWLJMet_singleLep2016.py
+++ b/LJMet/runFWLJMet_singleLep2016.py
@@ -700,6 +700,7 @@ BestCalc_cfg = cms.PSet(
     )
 HOTTaggerCalc_cfg = cms.PSet(
 
+    genParticles     = cms.InputTag("prunedGenParticles"),
     ak4PtCut         = cms.double(20),
     qgTaggerKey      = cms.string('QGTagger'),
     deepCSVBJetTags  = cms.string('pfDeepCSVJetTags'),

--- a/LJMet/runFWLJMet_singleLep2016_multipleTree.py
+++ b/LJMet/runFWLJMet_singleLep2016_multipleTree.py
@@ -696,6 +696,7 @@ BestCalc_cfg = cms.PSet(
     )
 HOTTaggerCalc_cfg = cms.PSet(
 
+    genParticles     = cms.InputTag("prunedGenParticles"),
     ak4PtCut         = cms.double(20),
     qgTaggerKey      = cms.string('QGTagger'),
     deepCSVBJetTags  = cms.string('pfDeepCSVJetTags'),

--- a/LJMet/runFWLJMet_singleLep2017.py
+++ b/LJMet/runFWLJMet_singleLep2017.py
@@ -744,6 +744,7 @@ BestCalc_cfg = cms.PSet(
     )
 HOTTaggerCalc_cfg = cms.PSet(
 
+    genParticles     = cms.InputTag("prunedGenParticles"),
     ak4PtCut         = cms.double(20),
     qgTaggerKey      = cms.string('QGTagger'),
     deepCSVBJetTags  = cms.string('pfDeepCSVJetTags'),

--- a/LJMet/runFWLJMet_singleLep2017_multipleTree.py
+++ b/LJMet/runFWLJMet_singleLep2017_multipleTree.py
@@ -742,6 +742,7 @@ BestCalc_cfg = cms.PSet(
     )
 HOTTaggerCalc_cfg = cms.PSet(
 
+    genParticles     = cms.InputTag("prunedGenParticles"),
     ak4PtCut         = cms.double(20),
     qgTaggerKey      = cms.string('QGTagger'),
     deepCSVBJetTags  = cms.string('pfDeepCSVJetTags'),

--- a/LJMet/runFWLJMet_singleLep2018.py
+++ b/LJMet/runFWLJMet_singleLep2018.py
@@ -746,6 +746,7 @@ BestCalc_cfg = cms.PSet(
 
 HOTTaggerCalc_cfg = cms.PSet(
 
+    genParticles     = cms.InputTag("prunedGenParticles"),
     ak4PtCut         = cms.double(20),
     qgTaggerKey      = cms.string('QGTagger'),
     deepCSVBJetTags  = cms.string('pfDeepCSVJetTags'),

--- a/LJMet/runFWLJMet_singleLep2018_multipleTree.py
+++ b/LJMet/runFWLJMet_singleLep2018_multipleTree.py
@@ -747,6 +747,7 @@ BestCalc_cfg = cms.PSet(
 
 HOTTaggerCalc_cfg = cms.PSet(
 
+    genParticles     = cms.InputTag("prunedGenParticles"),
     ak4PtCut         = cms.double(20),
     qgTaggerKey      = cms.string('QGTagger'),
     deepCSVBJetTags  = cms.string('pfDeepCSVJetTags'),

--- a/LJMet/runFWLJMet_singleLep2018_triggerTnP.py
+++ b/LJMet/runFWLJMet_singleLep2018_triggerTnP.py
@@ -703,6 +703,7 @@ BestCalc_cfg = cms.PSet(
 
 HOTTaggerCalc_cfg = cms.PSet(
 
+    genParticles     = cms.InputTag("prunedGenParticles"),
     ak4PtCut         = cms.double(20),
     qgTaggerKey      = cms.string('QGTagger'),
     deepCSVBJetTags  = cms.string('pfDeepCSVJetTags'),

--- a/LJMet/tester2016.py
+++ b/LJMet/tester2016.py
@@ -699,6 +699,7 @@ BestCalc_cfg = cms.PSet(
     )
 HOTTaggerCalc_cfg = cms.PSet(
 
+    genParticles     = cms.InputTag("prunedGenParticles"),
     ak4PtCut         = cms.double(20),
     qgTaggerKey      = cms.string('QGTagger'),
     deepCSVBJetTags  = cms.string('pfDeepCSVJetTags'),

--- a/LJMet/tester2017.py
+++ b/LJMet/tester2017.py
@@ -744,6 +744,7 @@ BestCalc_cfg = cms.PSet(
     )
 HOTTaggerCalc_cfg = cms.PSet(
 
+    genParticles     = cms.InputTag("prunedGenParticles"),
     ak4PtCut         = cms.double(20),
     qgTaggerKey      = cms.string('QGTagger'),
     deepCSVBJetTags  = cms.string('pfDeepCSVJetTags'),
@@ -886,4 +887,3 @@ process.p.associate(patAlgosToolsTask)
 # process.scedule = cms.Schedule(
 #     process.p,
 #     process.outpath)
-

--- a/LJMet/tester2018.py
+++ b/LJMet/tester2018.py
@@ -747,6 +747,7 @@ BestCalc_cfg = cms.PSet(
 
 HOTTaggerCalc_cfg = cms.PSet(
 
+    genParticles     = cms.InputTag("prunedGenParticles"),
     ak4PtCut         = cms.double(20),
     qgTaggerKey      = cms.string('QGTagger'),
     deepCSVBJetTags  = cms.string('pfDeepCSVJetTags'),


### PR DESCRIPTION
1. HOTTaggerCalc_cfg needs genParticles input tag for the new HOT tagger and is added to all config files.
2. In TTbarMassCalc, it is updated to select the hard processes for W decays. QUESTION: Should these collections of "top", "topb", and "topW" be aligned? Meaning fill these 3 collections together, instead of filling under different conditions. The latter method sometimes makes them useless downstream. 