### PR TITLE
Fixed some 2018 names and updated splitting for ttbar

### DIFF
--- a/LJMet/CRAB3/crab_config_template.py
+++ b/LJMet/CRAB3/crab_config_template.py
@@ -19,7 +19,7 @@ logFolder      = 'LOGFOLDER'
 Json_for_data  = 'JSONFORDATA'
 isMC           = ISMC
 isVLQsignal    = ISVLQSIGNAL
-
+isTTbar        = ISTTBAR
 ##############
 ### GENERAL
 ##############
@@ -59,12 +59,15 @@ if isMC:
 	if isVLQsignal:
 		config.Data.splitting = 'LumiBased'
 		config.Data.unitsPerJob = 2
+        elif isTTbar:
+                config.Data.splitting = "FileBased"
+                config.Data.unitsPerJob = 2
 	else:
 		config.Data.splitting = 'FileBased'
 		config.Data.unitsPerJob = 1
 else:
 	config.Data.splitting = 'Automatic'
-	config.Data.unitsPerJob = 720 
+	config.Data.unitsPerJob = 720
 	config.Data.lumiMask = Json_for_data
 
 config.Data.inputDBS = 'global'

--- a/LJMet/CRAB3/create_configs.py
+++ b/LJMet/CRAB3/create_configs.py
@@ -100,6 +100,7 @@ def create_crab_config( group, process, shifts ):
 	os.system( "sed -i 's|ISMC|{}|g' {}/{}".format( ISMC, CRABCONFIG_DIR, filename ) )
 	os.system( "sed -i 's|ISVLQSIGNAL|{}|g' {}/{}".format( ISVLQSIGNAL, CRABCONFIG_DIR, filename ) )
 	os.system( "sed -i 's|CRABSUBMITLOG|{}|g' {}/{}".format( CRABSUBMIT_DIR, CRABCONFIG_DIR, filename ) )
+	os.system( "sed -i 's|ISTTBAR|{}|g' {}/{}".format( ISTTBAR, CRABCONFIG_DIR, filename ) )
 
 	#replace strings in new cmsRun file
 	if ( ( "EGamma" in process ) or ( "Single" in process ) or ( "JetHT" in process ) ):

--- a/LJMet/CRAB3/sample_list_singleLep2017UL.py
+++ b/LJMet/CRAB3/sample_list_singleLep2017UL.py
@@ -58,13 +58,13 @@ groups = {
   },
   "TTBAR": {
     "TTToSemiLeptonic": "/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1/MINIAODSIM",
-    "TTToHadronic": "/TTToHadronic_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1/MINIAODSIM",
+    "TTToHadronic": "/TTToHadronic_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM",
     "TTTo2L2Nu": "/TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1/MINIAODSIM",
     "TTToSemiLeptonHT500Njet9": "/TTToSemiLepton_HT500Njet9_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM"
   },
   "TTMT": {
-    #"TTMT700": "/TT_Mtt-700to1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM",
-    #"TTMT1000": "/TT_Mtt-1000toInf_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM"
+    "TTMT700": "/TT_Mtt-700to1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM",
+    "TTMT1000": "/TT_Mtt-1000toInf_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM"
   },
   "TTBAR_SHIFTS": {
     "TTToSemiLeptonicHDUP": "/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1/MINIAODSIM",

--- a/LJMet/CRAB3/sample_list_singleLep2018UL.py
+++ b/LJMet/CRAB3/sample_list_singleLep2018UL.py
@@ -88,13 +88,13 @@ groups = {
     "DYMHT2500": "/DYJetsToLL_M-50_HT-2500toInf_TuneCP5_PSweights_13TeV-madgraphMLM-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1/MINIAODSIM"
   },
   "QCDHT": {
-    "QCDHT200": "/QCD_HT200to300_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v15-v1/MINIAODSIM",
-    "QCDHT300": "/QCD_HT300to500_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v15-v1/MINIAODSIM",
-    "QCDHT500": "/QCD_HT500to700_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v15-v1/MINIAODSIM",
-    "QCDHT700": "/QCD_HT700to1000_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v15-v1/MINIAODSIM",
-    "QCDHT1000": "/QCD_HT1000to1500_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v15-v1/MINIAODSIM",
-    "QCDHT1500": "/QCD_HT1500to2000_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v15-v1/MINIAODSIM",
-    "QCDHT2000": "/QCD_HT2000toInf_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v15-v1/MINIAODSIM",
+    "QCDHT200": "/QCD_HT200to300_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1/MINIAODSIM",
+    "QCDHT300": "/QCD_HT300to500_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1/MINIAODSIM",
+    "QCDHT500": "/QCD_HT500to700_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1/MINIAODSIM",
+    "QCDHT700": "/QCD_HT700to1000_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1/MINIAODSIM",
+    "QCDHT1000": "/QCD_HT1000to1500_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1/MINIAODSIM",
+    "QCDHT1500": "/QCD_HT1500to2000_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1/MINIAODSIM",
+    "QCDHT2000": "/QCD_HT2000toInf_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1/MINIAODSIM",
   },
   "WJETS": {
     "WJets": "/WJetsToLNu_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1/MINIAODSIM"
@@ -129,8 +129,8 @@ groups = {
     "STs": "/ST_s-channel_4f_leptonDecays_TuneCP5_13TeV-madgraph-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v15_ext1-v3/MINIAODSIM"
   },
   "EWK": {
-    "WW": "/WW_TuneCP5_PSweights_13TeV-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v15-v1/MINIAODSIM",
-    "WZ": "/WZ_TuneCP5_PSweights_13TeV-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v15-v1/MINIAODSIM",
+    "WW": "/WW_TuneCP5_13TeV-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1/MINIAODSIM",
+    "WZ": "/WZ_TuneCP5_13TeV-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1/MINIAODSIM",
     "ZZ": "/ZZ_TuneCP5_13TeV-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1/MINIAODSIM"
   }
 }

--- a/LJMet/CRAB3/sample_list_singleLep2018UL.py
+++ b/LJMet/CRAB3/sample_list_singleLep2018UL.py
@@ -53,14 +53,14 @@ groups = {
   # Not submitted
   },
   "TTBAR": {
-    "TTToSemiLeptonic": "/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v15-v1/MINIAODSIM",
-    "TTToHadronic": "/TTToHadronic_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v15-v1/MINIAODSIM",
-    "TTTo2L2Nu": "/TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v15-v1/MINIAODSIM",
-    "TTToSemiLeptonHT500Njet9": "/TTToSemiLepton_HT500Njet9_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v15-v1/MINIAODSIM" 
+    "TTToSemiLeptonic": "/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM",
+    "TTToHadronic": "/TTToHadronic_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1/MINIAODSIM",
+    "TTTo2L2Nu": "/TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1/MINIAODSIM",
+    "TTToSemiLeptonHT500Njet9": "/TTToSemiLepton_HT500Njet9_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM" 
   },
   "TTMT": {
-    #"TTMT700": "/TT_Mtt-700to1000_TuneCP5_PSweights_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v15-v1/MINIAODSIM",
-    #"TTMT1000": "/TT_Mtt-1000toInf_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v15-v1/MINIAODSIM"
+    "TTMT700": "/TT_Mtt-700to1000_TuneCP5_PSweights_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v15-v1/MINIAODSIM",
+    "TTMT1000": "/TT_Mtt-1000toInf_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v15-v1/MINIAODSIM"
   },
   "TTBAR_SHIFTS": {
     "TTToSemiLeptonicHDUP": "/TTToSemiLeptonic_hdampUP_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v15-v1/MINIAODSIM",

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ __Retrieving the `CMSSW` environment:__
 Note that if you are running a `bash` environment, the postfix should be `.sh` rather than `.csh` for `tcsh`. Also, `setenv [alias] [name]` in `tcsh` should be `export [alias]=[name]` in `bash`.
 
 For `tcsh`:
-
+	
+	cd ~/nobackup
 	source /cvmfs/cms.cern.ch/cmsset_default.csh
 	setenv SCRAM_ARCH slc7_amd64_gcc700
 	cmsrel CMSSW_10_6_29
@@ -25,7 +26,8 @@ For `tcsh`:
 	cmsenv
 
 For `bash`:
-
+	
+	cd ~/nobackup
 	source /cvmfs/cms.cern.ch/cmsset_default.sh
 	export SCRAM_ARCH=slc7_amd64_gcc700
 	cmsrel CMSSW_10_6_29


### PR DESCRIPTION
Didn't have the right extension for some 2018 samples, tried checking/updating most files, might still be a few lingering, but can fix easily once found.  Also, 2018 ttbar had >10k jobs so I changed from 1 --> 2 files per job if ttbar sample.