### PR TITLE
Fix for 2016APV/2016 data configs

### DIFF
--- a/LJMet/CRAB3/crab_config_template.py
+++ b/LJMet/CRAB3/crab_config_template.py
@@ -66,8 +66,8 @@ if isMC:
 		config.Data.splitting = 'FileBased'
 		config.Data.unitsPerJob = 1
 else:
-	config.Data.splitting = 'Automatic'
-	config.Data.unitsPerJob = 720
+	config.Data.splitting = 'FileBased'
+	config.Data.unitsPerJob = 2
 	config.Data.lumiMask = Json_for_data
 
 config.Data.inputDBS = 'global'

--- a/LJMet/CRAB3/create_configs.py
+++ b/LJMet/CRAB3/create_configs.py
@@ -64,6 +64,8 @@ def create_crab_config( group, process, shifts ):
 	#crab request name
 	REQNAME             = option.finalState+option.year + "UL"
 
+	MAXEVENTS = "-1"
+	
 	#eos out folder
 	OUTFOLDER           = "FWLJMET106XUL_{}{}UL_RunIISummer20".format( option.finalState, option.year ) if option.outfolder == "default" else option.outfolder
 	
@@ -84,7 +86,8 @@ def create_crab_config( group, process, shifts ):
 		DOGENHT = "False"
 	if group == "TEST":
 		OUTFOLDER += "_test"
-		
+		MAXEVENTS = "100"
+	
 	filename = 'crab_config_shifts_{}.py'.format( process ) if shifts else "crab_config_{}.py".format( process )
 	cmsRunname = 'runFWLJMet_shifts_{}.py'.format( process ) if shifts else "runFWLJMet_{}.py".format( process )
 
@@ -103,6 +106,8 @@ def create_crab_config( group, process, shifts ):
 	os.system( "sed -i 's|ISVLQSIGNAL|{}|g' {}/{}".format( ISVLQSIGNAL, CRABCONFIG_DIR, filename ) )
 	os.system( "sed -i 's|CRABSUBMITLOG|{}|g' {}/{}".format( CRABSUBMIT_DIR, CRABCONFIG_DIR, filename ) )
 	os.system( "sed -i 's|ISTTBAR|{}|g' {}/{}".format( ISTTBAR, CRABCONFIG_DIR, filename ) )
+	os.system( "sed -i 's|OUTPATH|{}|g' {}/{}".format( OUTPATH, CRABCONFIG_DIR, filename ) )
+	os.system( "sed -i 's|STORESITE|{}|g' {}/{}".format( STORESITE, CRABCONFIG_DIR, filename ) )
 
 	#replace strings in new cmsRun file
 	if ( ( "EGamma" in process ) or ( "Single" in process ) or ( "JetHT" in process ) ):
@@ -117,8 +122,7 @@ def create_crab_config( group, process, shifts ):
 	os.system( "sed -i 's|ISTTBAR|{}|g' {}/{}".format( ISTTBAR, CRABCONFIG_DIR, cmsRunname ) )
 	os.system( "sed -i 's|DOGENHT|{}|g' {}/{}".format( DOGENHT, CRABCONFIG_DIR, cmsRunname ) )
 	os.system( "sed -i 's|SHIFTS|{}|g' {}/{}".format( SHIFTS, CRABCONFIG_DIR, cmsRunname ) )
-	os.system( "sed -i 's|OUTPATH|{}|g' {}/{}".format( OUTPATH, CRABCONFIG_DIR, filename ) )
-	os.system( "sed -i 's|STORESITE|{}|g' {}/{}".format( STORESITE, CRABCONFIG_DIR, filename ) )
+        os.system( "sed -i 's|MAXEVENTS|{}|g' {}/{}".format( MAXEVENTS, CRABCONFIG_DIR, cmsRunname ) )
 
 if __name__=='__main__':
 	

--- a/LJMet/CRAB3/create_configs.py
+++ b/LJMet/CRAB3/create_configs.py
@@ -18,7 +18,6 @@ option = parser.parse_args()
 
 if option.finalState not in [ "singleLep", "doubleLep", "multiLep" ]: quit( "[ERR] Invalid -f (--finalState) argument passed." )
 if option.year not in [ "2016APV", "2016", "2017", "2018" ]: quit( "[ERR] Invalid -y (--year) argument passed." )
-SHIFTS = "True" if option.shifts else "False"
 	
 #Sample list file
 sampleListPath = "sample_list_{}{}UL.py".format( option.finalState, option.year )
@@ -51,6 +50,8 @@ else:
 	STORESITE = 'T3_US_FNALLPC'
 
 def create_crab_config( group, process, shifts ):
+        print( "   + {} > {}".format( group, process ) ), 
+
 	CMSRUNCONFIG        = '../runFWLJMet_{}{}UL.py'.format( option.finalState, option.year )
 
 
@@ -67,6 +68,7 @@ def create_crab_config( group, process, shifts ):
 	OUTFOLDER           = "FWLJMET106XUL_{}{}UL_RunIISummer20".format( option.finalState, option.year ) if option.outfolder == "default" else option.outfolder
 	
 	ISMC = "True" if ( ( process not in samples.groups[ "DATAE" ].keys() ) and ( process not in samples.groups[ "DATAM" ].keys() ) and ( process not in samples.groups[ "DATAJ" ].keys() ) ) else "False"
+        print( "(MC = {})".format( ISMC ) )
 	SHIFTS = "True" if shifts else "False"
 	try: 
 		ISVLQSIGNAL = "True" if process in samples.groups[ "VLQ" ].keys() else "False"
@@ -83,8 +85,8 @@ def create_crab_config( group, process, shifts ):
 	if group == "TEST":
 		OUTFOLDER += "_test"
 		
-	filename = 'crab_config_shifts_{}.py'.format( process ) if SHIFTS else "crab_config_{}.py".format( process )
-	cmsRunname = 'runFWLJMet_shifts_{}.py'.format( process ) if SHIFTS else "runFWLJMet_{}.py".format( process )
+	filename = 'crab_config_shifts_{}.py'.format( process ) if shifts else "crab_config_{}.py".format( process )
+	cmsRunname = 'runFWLJMet_shifts_{}.py'.format( process ) if shifts else "runFWLJMet_{}.py".format( process )
 
 	#copy template file to new directory
 	os.system( 'cp -v {} {}/{}'.format( CRABCONFIG_TEMPLATE, CRABCONFIG_DIR, filename ) )
@@ -121,10 +123,10 @@ def create_crab_config( group, process, shifts ):
 if __name__=='__main__':
 	
 	os.system('mkdir -vp '+CRABCONFIG_DIR)
-
+        print( "[START] Creating CRAB configurations" )
 	for group in option.groups:
 		if group not in list( samples.groups.keys() ):
 			print( "[WARN] {} is not a valid group listed in 'sample_list_{}{}UL.py'. Skipping.".format( group, option.finalState, option.year ) )
 		else:
 			for process in samples.groups[ group ]:
-				create_crab_config( group, process, SHIFTS )
+				create_crab_config( group, process, option.shifts )

--- a/LJMet/CRAB3/sample_list_singleLep2016APVUL.py
+++ b/LJMet/CRAB3/sample_list_singleLep2016APVUL.py
@@ -2,8 +2,8 @@ import os,sys
 
 groups = {
   "TEST": {
-    "TTTJ": "/TTTJ_TuneCP5_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM",
-    #"SingleElectronRun2016B": "/SingleElectron/Run2016B-ver2_HIPM_UL2016_MiniAODv2-v2/MINIAOD",
+    #"TTTJ": "/TTTJ_TuneCP5_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM",
+    "SingleElectronRun2016APVB": "/SingleElectron/Run2016B-ver2_HIPM_UL2016_MiniAODv2-v2/MINIAOD",
   },
   "DATAE": {
     "SingleElectronRun2016APVB": "/SingleElectron/Run2016B-ver2_HIPM_UL2016_MiniAODv2-v2/MINIAOD",

--- a/LJMet/CRAB3/sample_list_singleLep2016UL.py
+++ b/LJMet/CRAB3/sample_list_singleLep2016UL.py
@@ -2,7 +2,8 @@ import os,sys
 
 groups = {
   "TEST": {
-    "TTTJ": "/TTTJ_TuneCP5_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM",
+    #"TTTJ": "/TTTJ_TuneCP5_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM",
+    "SingleElectronRun2016H": "/SingleElectron/Run2016H-UL2016_MiniAODv2-v2/MINIAOD"
   },
   "DATAE": {
     "SingleElectronRun2016F": "/SingleElectron/Run2016F-UL2016_MiniAODv2-v2/MINIAOD",
@@ -10,14 +11,14 @@ groups = {
     "SingleElectronRun2016H": "/SingleElectron/Run2016H-UL2016_MiniAODv2-v2/MINIAOD",
   },
   "DATAM": {
-    "SingleMuonRun2016B": "/SingleMuon/Run2016F-UL2016_MiniAODv2-v2/MINIAOD",
-    "SingleMuonRun2016C": "/SingleMuon/Run2016G-UL2016_MiniAODv2-v2/MINIAOD",
-    "SingleMuonRun2016D": "/SingleMuon/Run2016H-UL2016_MiniAODv2-v2/MINIAOD",
+    "SingleMuonRun2016F": "/SingleMuon/Run2016F-UL2016_MiniAODv2-v2/MINIAOD",
+    "SingleMuonRun2016G": "/SingleMuon/Run2016G-UL2016_MiniAODv2-v2/MINIAOD",
+    "SingleMuonRun2016H": "/SingleMuon/Run2016H-UL2016_MiniAODv2-v2/MINIAOD",
   },
   "DATAJ": { # not a priority for now
-    "JetHTRun2016B": "/JetHT/Run2016F-UL2016_MiniAODv2-v2/MINIAOD", 
-    "JetHTRun2016C": "/JetHT/Run2016G-UL2016_MiniAODv2-v2/MINIAOD",
-    "JetHTRun2016D": "/JetHT/Run2016H-UL2016_MiniAODv2-v2/MINIAOD",
+    "JetHTRun2016F": "/JetHT/Run2016F-UL2016_MiniAODv2-v2/MINIAOD", 
+    "JetHTRun2016G": "/JetHT/Run2016G-UL2016_MiniAODv2-v2/MINIAOD",
+    "JetHTRun2016H": "/JetHT/Run2016H-UL2016_MiniAODv2-v2/MINIAOD",
   },
   "CHARGEDHIGGS": {
     "HPTB200": "/ChargedHiggs_HplusTB_HplusToTB_M-200_TuneCP5_13TeV_amcatnlo_pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM",

--- a/LJMet/CRAB3/sample_list_singleLep2016UL.py
+++ b/LJMet/CRAB3/sample_list_singleLep2016UL.py
@@ -96,7 +96,7 @@ groups = {
     "QCDHT2000": "/QCD_HT2000toInf_TuneCP5_PSWeights_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1/MINIAODSIM"
   },
   "WJETS": {
-    "WJets": "/TTWJetsToLNu_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1/MINIAODSIM"
+    "WJets": "/WJetsToLNu_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM"
   },
   "WJETSHT": {
     "WJetsHT200": "/WJetsToLNu_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1/MINIAODSIM",

--- a/LJMet/CRAB3/sample_list_singleLep2017UL.py
+++ b/LJMet/CRAB3/sample_list_singleLep2017UL.py
@@ -101,7 +101,7 @@ groups = {
     "QCDHT2000": "/QCD_HT200To300_TuneCP5_PSWeights_13TeV-madgraph-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1/MINIAODSIM",
   },
   "WJETS": {
-    "WJets": "/WJetsToLNu_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1/MINIAODSIM" 
+    "WJets": "/WJetsToLNu_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM" 
   },
   "WJETSHT": {
     "WJetsHT200": "/WJetsToLNu_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v1/MINIAODSIM",

--- a/LJMet/CRAB3/sample_list_singleLep2018UL.py
+++ b/LJMet/CRAB3/sample_list_singleLep2018UL.py
@@ -97,7 +97,7 @@ groups = {
     "QCDHT2000": "/QCD_HT2000toInf_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1/MINIAODSIM",
   },
   "WJETS": {
-    "WJets": "/WJetsToLNu_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1/MINIAODSIM"
+    "WJets": "/WJetsToLNu_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM"
   },
   "WJETSHT": {
     "WJetsHT200": "/WJetsToLNu_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v1/MINIAODSIM",

--- a/LJMet/CRAB3/submit_crab_jobs.py
+++ b/LJMet/CRAB3/submit_crab_jobs.py
@@ -4,6 +4,7 @@ parser = argparse.ArgumentParser()
 parser.add_argument( "-f", "--folder", required = True, help = "singleLep,doubleLep,multiLep" )
 parser.add_argument( "-g", "--groups", nargs = "+", required = True )
 parser.add_argument( "--shifts", action = "store_true" )
+parser.add_argument( "--dryrun", action = "store_true" )
 option = parser.parse_args()
 
 #Sample list file
@@ -19,10 +20,16 @@ def submit_crab_job( group, process, shifts, failed_submissions ):
     crab_cfg = os.path.join( CRABCONFIG_DIR, "crab_config_shifts_{}.py".format( process ) )
   else:
     crab_cfg = os.path.join( CRABCONFIG_DIR, "crab_config_{}.py".format( process ) )
-  try: 
-    os.system( "crab submit {}".format( crab_cfg ) )
-  except:
-    failed_submissions.append( process )
+  if option.dryrun:
+    try: 
+      os.system( "crab submit --dryrun {}".format( crab_cfg ) )
+    except:
+      pass
+  else:
+    try: 
+      os.system( "crab submit {}".format( crab_cfg ) )
+    except:
+      failed_submissions.append( process )
 
 if __name__ == '__main__':
   print( "[START] Submitting CRAB3 jobs" )

--- a/LJMet/plugins/JetMETCorrHelper.cc
+++ b/LJMet/plugins/JetMETCorrHelper.cc
@@ -1,18 +1,12 @@
-
-
 #include "FWLJMET/LJMet/interface/JetMETCorrHelper.h"
 
 using namespace std;
 
-JetMETCorrHelper::JetMETCorrHelper()
-{
-}
+JetMETCorrHelper::JetMETCorrHelper(){}
 
-JetMETCorrHelper::JetMETCorrHelper(const edm::ParameterSet& iConfig)
-{
+JetMETCorrHelper::JetMETCorrHelper(const edm::ParameterSet& iConfig){
     Initialize(iConfig);
 }
-
 
 void JetMETCorrHelper::Initialize(const edm::ParameterSet& iConfig){
 
@@ -27,9 +21,10 @@ void JetMETCorrHelper::Initialize(const edm::ParameterSet& iConfig){
     std::string JERSF_txtfile            = iConfig.getParameter<edm::FileInPath>("JERSF_txtfile").fullPath();
     std::string JER_txtfile              = iConfig.getParameter<edm::FileInPath>("JER_txtfile").fullPath();
     std::string JERAK8_txtfile           = iConfig.getParameter<edm::FileInPath>("JERAK8_txtfile").fullPath();
-    int year = 2018;
-    if(JEC_txtfile.find("UL17") != std::string::npos) year = 2017;
-    else if(JEC_txtfile.find("Summer16") != std::string::npos) year = 2016;
+    std::string year = "2018";
+    if(JEC_txtfile.find("UL17") != std::string::npos) year = "2017";
+    else if(JEC_txtfile.find("UL16APV") != std::string::npos) year = "2016APV";
+    else if(JEC_txtfile.find("UL16") != std::string::npos) year = "2016";
 
     if(debug) std::cout << mLegend << "Using JEC files JEC_txtfile    : " << JEC_txtfile << std::endl;
     if(debug) std::cout << mLegend << "Using JEC files JERSF_txtfile  : " << JERSF_txtfile << std::endl;
@@ -86,23 +81,24 @@ void JetMETCorrHelper::Initialize(const edm::ParameterSet& iConfig){
       // Create the JetCorrectorParameter objects, the order does not matter.
 
       std::string searchStr = "A_V";
-      if(year == 2018){
+      if(year == "2018"){
 	mEraReplaceStr["A"] = "A_V";
 	mEraReplaceStr["B"] = "B_V";
 	mEraReplaceStr["C"] = "C_V";
 	mEraReplaceStr["D"] = "D_V";
-      }else if(year == 2017){
+      }else if(year == "2017"){
 	searchStr = "B_V";
 	mEraReplaceStr["B"] = "B_V";
 	mEraReplaceStr["C"] = "C_V";
 	mEraReplaceStr["D"] = "D_V";
 	mEraReplaceStr["E"] = "E_V";
 	mEraReplaceStr["F"] = "F_V";
-      }else{ // 2016
-	searchStr = "BCD_V";
-	mEraReplaceStr["BCD"] = "BCD_V";
-	mEraReplaceStr["EF"] = "EF_V";
-	mEraReplaceStr["GH"] = "GH_V";
+      }else if(year == "2016APV"){ 
+	searchStr = "BCDEF_V";
+	mEraReplaceStr["BCDEF"] = "BCDEF_V";
+      }else if(year == "2016"){
+        searchStr = "FGH_V";
+        mEraReplaceStr["FGH"] = "FGH_V";
       }
 
       for (std::map<std::string,std::string>::iterator it=mEraReplaceStr.begin();it!=mEraReplaceStr.end();it++){
@@ -181,19 +177,19 @@ void JetMETCorrHelper::SetFacJetCorr(edm::EventBase const & event)
   // run # get in https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions18/13TeV/Era/Prompt/
 
   if(iRun <= 276812){
-  	if(debug) std::cout << "\t\t\t using 2016 JEC for era BCD "<< std::endl;
-  	JetCorrector = mEraFacJetCorr["BCD"];
-  	JetCorrectorAK8 = mEraFacJetCorrAK8["BCD"];
+  	if(debug) std::cout << "\t\t\t using 2016 APV JEC for era BCD "<< std::endl;
+  	JetCorrector = mEraFacJetCorr["BCDEF"];
+  	JetCorrectorAK8 = mEraFacJetCorrAK8["BCDEF"];
   }
   else if(iRun <= 278801){
-  	if(debug) std::cout << "\t\t\t using 2016 JEC for era EF "<< std::endl;
-  	JetCorrector = mEraFacJetCorr["EF"];
-  	JetCorrectorAK8 = mEraFacJetCorrAK8["EF"];
+  	if(debug) std::cout << "\t\t\t using 2016 APV JEC for era EF "<< std::endl;
+  	JetCorrector = mEraFacJetCorr["BCDEF"];
+  	JetCorrectorAK8 = mEraFacJetCorrAK8["BCDEF"];
   }
   else if(iRun <= 284045){
-  	if(debug) std::cout << "\t\t\t using 2016 JEC for era GH "<< std::endl;
-  	JetCorrector = mEraFacJetCorr["GH"];
-  	JetCorrectorAK8 = mEraFacJetCorrAK8["GH"];
+  	if(debug) std::cout << "\t\t\t using 2016 JEC for era FGH "<< std::endl;
+  	JetCorrector = mEraFacJetCorr["FGH"];
+  	JetCorrectorAK8 = mEraFacJetCorrAK8["FGH"];
   }
   else if(iRun <= 299330){
   	if(debug) std::cout << "\t\t\t using 2017 JEC for era B "<< std::endl;

--- a/LJMet/runFWLJMet_singleLep2016APVUL.py
+++ b/LJMet/runFWLJMet_singleLep2016APVUL.py
@@ -23,7 +23,7 @@ options.inputFiles = [
   #"root://cmsxrootd.fnal.gov//store/mc/RunIISummer20UL16MiniAODAPVv2/TTTT_TuneCP5_13TeV-amcatnlo-pythia8/MINIAODSIM/106X_mcRun2_asymptotic_preVFP_v11-v2/100000/0AD9EE2D-6792-A54B-AF1C-1BDED1C9A994.root",
   "/store/mc/RunIISummer20UL16MiniAODAPVv2/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/MINIAODSIM/106X_mcRun2_asymptotic_preVFP_v11-v1/120000/2CF6A298-801D-DE4E-A94D-9F1EFC07D2DD.root"
 ]
-options.maxEvents = -1
+options.maxEvents = MAXEVENTS
 options.parseArguments()
 
 isMC= options.isMC

--- a/LJMet/runFWLJMet_singleLep2016UL.py
+++ b/LJMet/runFWLJMet_singleLep2016UL.py
@@ -23,7 +23,7 @@ options.inputFiles = [
     #"root://cmsxrootd.fnal.gov//store/mc/RunIISummer20UL16MiniAODv2/TTTT_TuneCP5_13TeV-amcatnlo-pythia8/MINIAODSIM/106X_mcRun2_asymptotic_v17-v2/2430000/074033FA-63D9-8D4F-89F7-E0F96C6F2846.root"
     "root://cmsxrootd.fnal.gov//store/mc/RunIISummer20UL16MiniAODv2/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/MINIAODSIM/106X_mcRun2_asymptotic_v17-v1/120000/01572CA8-C7AE-0346-B660-8AB4F7C2AE36.root"
 ]
-options.maxEvents = -1
+options.maxEvents = MAXEVENTS
 options.parseArguments()
 
 isMC= options.isMC

--- a/LJMet/runFWLJMet_singleLep2017UL.py
+++ b/LJMet/runFWLJMet_singleLep2017UL.py
@@ -22,7 +22,7 @@ options.shifts = SHIFTS
 options.inputFiles = [
 "/store/mc/RunIISummer20UL17MiniAODv2/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/MINIAODSIM/106X_mc2017_realistic_v9-v1/00000/005708B7-331C-904E-88B9-189011E6C9DD.root"
 ]
-options.maxEvents = -1
+options.maxEvents = MAXEVENTS
 options.parseArguments()
 
 isMC= options.isMC

--- a/LJMet/runFWLJMet_singleLep2018UL.py
+++ b/LJMet/runFWLJMet_singleLep2018UL.py
@@ -22,7 +22,7 @@ options.shifts = SHIFTS
 options.inputFiles = [
   "/store/mc/RunIISummer20UL18MiniAODv2/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/MINIAODSIM/106X_upgrade2018_realistic_v16_L1v1-v2/120000/006455CD-9CDB-B843-B50D-5721C39F30CE.root"
 ]
-options.maxEvents = -1
+options.maxEvents = MAXEVENTS
 options.parseArguments()
 
 isMC= options.isMC

--- a/LJMet/tester2016APVUL.py
+++ b/LJMet/tester2016APVUL.py
@@ -14,16 +14,17 @@ options.register( 'shifts', '', VarParsing.multiplicity.singleton, VarParsing.va
 
 ## SET DEFAULT VALUES
 ## ATTENTION: THESE DEFAULT VALUES ARE SET FOR VLQ SIGNAL ! isMC=True, isTTbar=False, isVLQsignal=True 
-options.isMC = True
-options.isTTbar = True
+options.isMC = False
+options.isTTbar = False
 options.isVLQsignal = False
 options.doGenHT = False
-options.shifts = True
+options.shifts = False
 options.inputFiles = [
   #"root://cmsxrootd.fnal.gov//store/mc/RunIISummer20UL16MiniAODAPVv2/TTTT_TuneCP5_13TeV-amcatnlo-pythia8/MINIAODSIM/106X_mcRun2_asymptotic_preVFP_v11-v2/100000/0AD9EE2D-6792-A54B-AF1C-1BDED1C9A994.root",
-  "/store/mc/RunIISummer20UL16MiniAODAPVv2/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/MINIAODSIM/106X_mcRun2_asymptotic_preVFP_v11-v1/120000/2CF6A298-801D-DE4E-A94D-9F1EFC07D2DD.root"
+  #"/store/mc/RunIISummer20UL16MiniAODAPVv2/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/MINIAODSIM/106X_mcRun2_asymptotic_preVFP_v11-v1/120000/2CF6A298-801D-DE4E-A94D-9F1EFC07D2DD.root"
+  "/store/data/Run2016B/SingleMuon/MINIAOD/ver2_HIPM_UL2016_MiniAODv2-v2/120000/0042DCA3-FD73-4641-B984-636AA05DFB55.root"
 ]
-options.maxEvents = 2000
+options.maxEvents = 200
 options.parseArguments()
 
 isMC= options.isMC

--- a/LJMet/tester2016UL.py
+++ b/LJMet/tester2016UL.py
@@ -14,16 +14,18 @@ options.register('shifts', '', VarParsing.multiplicity.singleton, VarParsing.var
 
 ## SET DEFAULT VALUES
 ## ATTENTION: THESE DEFAULT VALUES ARE SET FOR VLQ SIGNAL ! isMC=True, isTTbar=False, isVLQsignal=True 
-options.isMC = True
-options.isTTbar = True
+options.isMC = False
+options.isTTbar = False
 options.isVLQsignal = False
 options.doGenHT = False
-options.shifts = True
+options.shifts = False
 options.inputFiles = [
     #"root://cmsxrootd.fnal.gov//store/mc/RunIISummer20UL16MiniAODv2/TTTT_TuneCP5_13TeV-amcatnlo-pythia8/MINIAODSIM/106X_mcRun2_asymptotic_v17-v2/2430000/074033FA-63D9-8D4F-89F7-E0F96C6F2846.root"
-    "root://cmsxrootd.fnal.gov//store/mc/RunIISummer20UL16MiniAODv2/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/MINIAODSIM/106X_mcRun2_asymptotic_v17-v1/120000/01572CA8-C7AE-0346-B660-8AB4F7C2AE36.root"
+    #"root://cmsxrootd.fnal.gov//store/mc/RunIISummer20UL16MiniAODv2/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/MINIAODSIM/106X_mcRun2_asymptotic_v17-v1/120000/01572CA8-C7AE-0346-B660-8AB4F7C2AE36.root"
+    #"root://cmsxrootd.fnal.gov//store/data/Run2016F/SingleElectron/MINIAOD/UL2016_MiniAODv2-v2/270000/4C3CDA2A-5A33-D542-A15A-DE2B3CD924E7.root"
+    "root://cmsxrootd.fnal.gov//store/data/Run2016F/SingleMuon/MINIAOD/UL2016_MiniAODv2-v2/70000/060F0B51-FCEF-F343-890C-3043A4B268C2.root"
 ]
-options.maxEvents = 2000
+options.maxEvents = 200
 options.parseArguments()
 
 isMC= options.isMC

--- a/LJMet/tester2017UL.py
+++ b/LJMet/tester2017UL.py
@@ -14,14 +14,16 @@ options.register( 'shifts', '', VarParsing.multiplicity.singleton, VarParsing.va
 
 ## SET DEFAULT VALUES
 ## ATTENTION: THESE DEFAULT VALUES ARE SET FOR VLQ SIGNAL ! isMC=True, isTTbar=False, isVLQsignal=True 
-options.isMC = True
-options.isTTbar = True 
+options.isMC = False
+options.isTTbar = False 
 options.isVLQsignal = False 
 options.doGenHT = False
-options.shifts = True
+options.shifts = False
 options.inputFiles = [
-"/store/mc/RunIISummer20UL17MiniAODv2/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/MINIAODSIM/106X_mc2017_realistic_v9-v1/00000/005708B7-331C-904E-88B9-189011E6C9DD.root"
+#"/store/mc/RunIISummer20UL17MiniAODv2/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/MINIAODSIM/106X_mc2017_realistic_v9-v1/00000/005708B7-331C-904E-88B9-189011E6C9DD.root"
+"root://cmsxrootd.fnal.gov//store/data/Run2017B/SingleMuon/MINIAOD/UL2017_MiniAODv2-v1/260000/9032A966-8ED0-B645-97B6-A8EBC1D8D3B9.root"
 ]
+
 options.maxEvents = 1000
 options.parseArguments()
 


### PR DESCRIPTION
Didn't update the 2016 data jec/jer reading in JetMETCorrHelper.cc previously so there were issues with reading the correct file, but these should be fixed now.  Also updated the crab config creation to fine tune the testing --> i.e. fewer events, job splitting 